### PR TITLE
Multi-threaded decoding process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ DEPENDENCY_SOURCE_DIRECTORY_LIBAVIF := $(DEPENDENCY_SOURCE_DIRECTORY)/libavif
 DEPENDENCY_SOURCE_FILE_DAV1D := $(DEPENDENCY_SOURCE_DIRECTORY)/dav1d.tar.bz2
 DEPENDENCY_SOURCE_FILE_LIBAVIF := $(DEPENDENCY_SOURCE_DIRECTORY)/libavif.tar.gz
 
-DEPENDENCY_SOURCE_URL_DAV1D := https://code.videolan.org/videolan/dav1d/-/archive/1.0.0/dav1d-1.0.0.tar.bz2
-DEPENDENCY_SOURCE_URL_LIBAVIF := https://github.com/AOMediaCodec/libavif/archive/refs/tags/v0.11.1.tar.gz
+DEPENDENCY_SOURCE_URL_DAV1D := https://code.videolan.org/videolan/dav1d/-/archive/1.2.1/dav1d-1.2.1.tar.bz2
+DEPENDENCY_SOURCE_URL_LIBAVIF := https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.0.0.tar.gz
 
 $(DEPENDENCY_SOURCE_FILE_DAV1D): | $(DEPENDENCY_SOURCE_DIRECTORY)
 	curl --location --output $@ $(DEPENDENCY_SOURCE_URL_DAV1D)

--- a/extractor.c
+++ b/extractor.c
@@ -35,8 +35,11 @@ int getBMPFromAVIF(const uint8_t *input_data, size_t file_size,
 	int bit_width, bit_length;
 	avifRGBImage rgb;
 	memset(&rgb, 0, sizeof(rgb));
+	SYSTEM_INFO info;
 
 	avifDecoder *decoder = avifDecoderCreate();
+	GetSystemInfo(&info);
+	decoder->maxThreads = info.dwNumberOfProcessors;
 	avifResult result = avifDecoderSetIOMemory(decoder, input_data, file_size);
 	if (result != AVIF_RESULT_OK)
 	{
@@ -57,6 +60,7 @@ int getBMPFromAVIF(const uint8_t *input_data, size_t file_size,
 		avifRGBImageSetDefaults(&rgb, decoder->image);
 		rgb.depth = 8;
 		rgb.format = AVIF_RGB_FORMAT_BGRA;
+		rgb.maxThreads = info.dwNumberOfProcessors;
 
 		*h_bitmap_data = LocalAlloc(LMEM_MOVEABLE, sizeof(uint8_t) * bit_length * height);
 		if (!*h_bitmap_data)


### PR DESCRIPTION
By setting the `maxThreads` variable in the `avifDecoder` structure, the `avifDecoderNextImage` function is multithreaded.
By setting the `maxThreads` variable in the `avifRGBImage` structure, the `avifImageYUVToRGB` function is multithreaded.

If this pull request meets with your approval, could you kindly proceed with the build and subsequent release?
Your consideration is greatly appreciated.